### PR TITLE
v1.1.0 - Fix BEMModifiers type to an interface and document it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.1.0
+- Fix `BEMModifiers` type to an interface with optional values and document it in the README.
+
 ## v1.0.1
 - Ignore (don't package) build-related files.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ The new `b` function from above can be called in two different ways:
 
 Constructs the BEM block class names (e.g., `foo foo--mod1 foo--mod2`).
 
+See the [`BEMModifiers`](#bemmodifiers-interface) section below for the modifiers interface.
+
 ### `b( elementName [, elementModifiers] )`
 
 Constructs the BEM element class names (e.g., `foo__bar foo__bar--mod1 foo__bar--mod2)`).
+
+See the [`BEMModifiers`](#bemmodifiers-interface) section below for the modifiers interface.
 
 _Let's see it in action!_
 
@@ -85,6 +89,16 @@ export const Foo = ({ blockName, children }) => {
       {children}
     </div>
   )
+}
+```
+
+### `BEMModifiers` Interface
+
+All modifiers must be provided as a hash with `Boolean` or `undefined` values:
+
+```ts
+export interface BEMModifiers {
+	[modifierName: string]: boolean | undefined
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-join",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A function used to construct BEM class names.",
   "keywords": [
     "bem",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import bemJoin from './'
+import bemJoin, { BEMModifiers } from './'
 
 test('calling bemJoin("foo")() returns "foo"', t => {
 	t.is(bemJoin('foo')(), 'foo')
@@ -82,3 +82,15 @@ test('calling bemJoin with partial options uses default options for the missing 
 		'foo__bar foo__baryybaz',
 	)
 })
+
+export interface TestModifiers extends BEMModifiers {
+	foo: boolean
+	bar?: boolean
+	baz?: boolean
+}
+
+export const testModifiers: TestModifiers = {
+	foo: true,
+	bar: undefined,
+	// intentionally missing baz
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,8 @@ export default bemJoin as CurryBlockName & CurryOptions
 /**
  * BEM modifiers for blocks and elements.
  */
-export type BEMModifiers = {
-	[modifierName: string]: boolean
+export interface BEMModifiers {
+	[modifierName: string]: boolean | undefined
 }
 
 export interface CurryBlockName {


### PR DESCRIPTION
## v1.1.0
- Fix `BEMModifiers` type to an interface with optional values and document it in the README.